### PR TITLE
fix: install command on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://dcyou.github.io/resume/
 
 ``` bash
 # install dependencies
-$ npm run install
+$ npm install
 
 # serve with hot reload at localhost:3000
 $ npm run dev


### PR DESCRIPTION
_npm run install_ gives the following output:

npm ERR! missing script: install

npm ERR! A complete log of this run can be found in:
...

The right command is just `npm install`